### PR TITLE
fix(TableView): table cell not selectable when  resizable is set

### DIFF
--- a/packages/extension-table/src/table/TableView.ts
+++ b/packages/extension-table/src/table/TableView.ts
@@ -103,6 +103,16 @@ export class TableView implements NodeView {
   }
 
   ignoreMutation(mutation: ViewMutationRecord) {
-    return mutation.type === 'attributes' && (mutation.target === this.table || this.colgroup.contains(mutation.target))
+    const target = mutation.target as Node
+    const isInsideWrapper = this.dom.contains(target)
+    const isInsideContent = this.contentDOM.contains(target)
+
+    if (isInsideWrapper && !isInsideContent) {
+      if (mutation.type === 'attributes' || mutation.type === 'childList' || mutation.type === 'characterData') {
+        return true
+      }
+    }
+
+    return false
   }
 }


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->

## Implementation Approach

<!-- Describe your approach to implementing these changes. Keep it concise. -->
When using the Table extension with resizable: true, the editor keeps replacing the <div class="tableWrapper"> DOM node on every transaction.
This causes:

The DOM element "blinks" (you can see it re-created in the DOM inspector).
Any table cell selection (.selectedCell) is immediately lost, making it impossible to keep cells selected long enough to call mergeCells().

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
