### PR TITLE
React: BubbleMenu now reacts to prop changes

### DIFF
--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -36,7 +36,6 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
 
     useEffect(() => {
       const bubbleMenuElement = menuEl.current
-
       bubbleMenuElement.style.visibility = 'hidden'
       bubbleMenuElement.style.position = 'absolute'
 
@@ -74,7 +73,17 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
         })
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [editor, currentEditor])
+    }, [
+      editor,
+      currentEditor,
+      pluginKey,
+      updateDelay,
+      resizeDelay,
+      appendTo,
+      shouldShow,
+      getReferencedVirtualElement,
+      options,
+    ])
 
     return createPortal(<div {...restProps}>{children}</div>, menuEl.current)
   },

--- a/packages/react/src/menus/BubbleMenu.tsx
+++ b/packages/react/src/menus/BubbleMenu.tsx
@@ -72,7 +72,6 @@ export const BubbleMenu = React.forwardRef<HTMLDivElement, BubbleMenuProps>(
           }
         })
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
       editor,
       currentEditor,


### PR DESCRIPTION
## Changes Overview

<!-- Briefly describe your changes. -->
Fixed an issue where the React BubbleMenu didn’t pick up prop changes after initial mount. In particular, updates to **options** according to issue # 

## Implementation Approach
The effect that registers the BubbleMenu plugin now includes all relevant configuration in its dependency list.
<!-- Describe your approach to implementing these changes. Keep it concise. -->

## Testing Done

<!-- Explain how you tested these changes. Link to test scenarios or specs if relevant. -->

## Verification Steps

<!-- Describe steps reviewers can take to verify the functionality of your changes. -->

## Additional Notes

<!-- Add any other notes or screenshots about the PR here. -->

## Checklist

- [x] I have created a [changeset](https://github.com/changesets/changesets) for this PR if necessary.
- [x] My changes do not break the library.
- [x] I have added tests where applicable.
- [x] I have followed the project guidelines.
- [x] I have fixed any lint issues.

## Related Issues

<!-- Link any related issues here -->
